### PR TITLE
This commit allows users to set the module download directory in the …

### DIFF
--- a/Terrafile.example
+++ b/Terrafile.example
@@ -1,3 +1,5 @@
+vendor_dir: vendor/modules
+
 terrafile-test-registry:
   source: "terraform-digitalocean-modules/droplet/digitalocean"
   version: "0.1.x"

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -45,9 +45,9 @@ var installCmd = &cobra.Command{
 		os.MkdirAll(VendorDir, os.ModePerm)
 
 		var wg sync.WaitGroup
-		wg.Add(len(Config))
+		wg.Add(len(Config.Modules))
 
-		for moduleName, moduleMeta := range Config {
+		for moduleName, moduleMeta := range Config.Modules {
 			go getModule(moduleName, moduleMeta, &wg)
 		}
 		wg.Wait()


### PR DESCRIPTION
Allows users to set `vendor_dir: some/path` in their Terrafile.

This allows for easier updates / upgrades to version 2.0 which changed the default module directory from `vendor/xterrafile` to `vendor/modules`.

Users looking to update to 2.0 can set `vendor_dir: vendor/xterrafile` in their Terrafile and don't have to update CI tasks with `-d ...` or update their all of their usage of modules.

Closes #12 