### PR TITLE
WIP: Add function to return module version from a slice of string versions

### DIFF
--- a/Terrafile.example
+++ b/Terrafile.example
@@ -2,7 +2,7 @@ vendor_dir: vendor/modules
 
 terrafile-test-registry:
   source: "terraform-digitalocean-modules/droplet/digitalocean"
-  version: "0.1.x"
+  #version: "0.1.x"
 terrafile-test-https:
   source: "github.com/terraform-digitalocean-modules/terraform-digitalocean-droplet.git"
 terrafile-test-tag:

--- a/pkg/module_version.go
+++ b/pkg/module_version.go
@@ -1,0 +1,56 @@
+// Copyright © 2019 Tim Birkett <tim.birkett@devopsmakers.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xterrafile
+
+import (
+	"errors"
+
+	"github.com/blang/semver"
+)
+
+func getModuleVersion(sourceVersions []string, versionConditional string) (string, error) {
+	var validSourceVersions []semver.Version
+
+	validModuleVersionRange, err := semver.ParseRange(versionConditional)
+	if err != nil {
+		return "", err
+	}
+
+	for _, sourceVersion := range sourceVersions {
+		v, err := semver.ParseTolerant(sourceVersion)
+		if err != nil {
+			continue
+		}
+		validSourceVersions = append(validSourceVersions, v)
+	}
+
+	semver.Sort(validSourceVersions)
+
+	for i := range validSourceVersions {
+		v := validSourceVersions[len(validSourceVersions)-1-i]
+		if validModuleVersionRange(v) {
+			return v.String(), nil
+		}
+	}
+
+	err = errors.New("Unable to find a valid version of this module")
+	return "", err
+}

--- a/pkg/module_version.go
+++ b/pkg/module_version.go
@@ -45,11 +45,6 @@ func isConditionalVersion(versionConditional string) bool {
 func getModuleVersion(sourceVersions []string, versionConditional string) (string, error) {
 	var validSourceVersions []semver.Version
 
-	validModuleVersionRange, err := semver.ParseRange(versionConditional)
-	if err != nil {
-		return "", err
-	}
-
 	for _, sourceVersion := range sourceVersions {
 		v, err := semver.ParseTolerant(sourceVersion)
 		if err != nil {
@@ -59,6 +54,15 @@ func getModuleVersion(sourceVersions []string, versionConditional string) (strin
 	}
 
 	semver.Sort(validSourceVersions)
+
+	if versionConditional == "" {
+		return validSourceVersions[len(validSourceVersions)-1].String(), nil
+	}
+
+	validModuleVersionRange, err := semver.ParseRange(versionConditional)
+	if err != nil {
+		return "", err
+	}
 
 	for i := range validSourceVersions {
 		v := validSourceVersions[len(validSourceVersions)-1-i]

--- a/pkg/module_version.go
+++ b/pkg/module_version.go
@@ -55,6 +55,7 @@ func getModuleVersion(sourceVersions []string, versionConditional string) (strin
 
 	semver.Sort(validSourceVersions)
 
+	// Assume latest if we get passed an empty string
 	if versionConditional == "" {
 		return validSourceVersions[len(validSourceVersions)-1].String(), nil
 	}

--- a/pkg/module_version.go
+++ b/pkg/module_version.go
@@ -26,6 +26,14 @@ import (
 	"github.com/blang/semver"
 )
 
+func isValidVersion(version string) bool {
+	_, err := semver.ParseTolerant(version)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 func isConditionalVersion(versionConditional string) bool {
 	_, err := semver.ParseRange(versionConditional)
 	if err != nil {

--- a/pkg/module_version.go
+++ b/pkg/module_version.go
@@ -26,6 +26,14 @@ import (
 	"github.com/blang/semver"
 )
 
+func isConditionalVersion(versionConditional string) bool {
+	_, err := semver.ParseRange(versionConditional)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 func getModuleVersion(sourceVersions []string, versionConditional string) (string, error) {
 	var validSourceVersions []semver.Version
 

--- a/pkg/module_version_test.go
+++ b/pkg/module_version_test.go
@@ -23,14 +23,20 @@ func TestGetModuleVersion(t *testing.T) {
 	var err error
 
 	version, _ = getModuleVersion([]string{"1.1.1", "2.1.1", "2.0.1"}, "1.1.1")
-	assert.Equal(t, "1.1.1", version, "version should be >= 2.0.0 < 2.2.0")
+	assert.Equal(t, "1.1.1", version, "version should be 1.1.1")
+
+	version, _ = getModuleVersion([]string{"1.1.1", "2.1.1", "2.0.1"}, "")
+	assert.Equal(t, "2.1.1", version, "version should be 2.1.1")
 
 	version, _ = getModuleVersion([]string{"1.1.1", "not-a-version", "2.1.1", "2.0.1"}, ">= 2.0.0 < 2.2.0")
-	assert.Equal(t, "2.1.1", version, "version should be 1.1.1")
+	assert.Equal(t, "2.1.1", version, "version should be 2.1.1")
 
 	_, err = getModuleVersion([]string{"1.1.1", "2.1.1", "2.0.1"}, ">= no < version")
 	assert.EqualError(t, err, "Could not get version from string: \">=no\"")
 
 	_, err = getModuleVersion([]string{"not", "a", "version"}, ">= 2.0.0 < 2.2.0")
+	assert.EqualError(t, err, "Unable to find a valid version of this module")
+
+	_, err = getModuleVersion([]string{}, ">= 2.0.0 < 2.2.0")
 	assert.EqualError(t, err, "Unable to find a valid version of this module")
 }

--- a/pkg/module_version_test.go
+++ b/pkg/module_version_test.go
@@ -1,0 +1,24 @@
+package xterrafile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetModuleVersion(t *testing.T) {
+	var version string
+	var err error
+
+	version, _ = getModuleVersion([]string{"1.1.1", "2.1.1", "2.0.1"}, "1.1.1")
+	assert.Equal(t, "1.1.1", version, "version should be >= 2.0.0 < 2.2.0")
+
+	version, _ = getModuleVersion([]string{"1.1.1", "not-a-version", "2.1.1", "2.0.1"}, ">= 2.0.0 < 2.2.0")
+	assert.Equal(t, "2.1.1", version, "version should be 1.1.1")
+
+	_, err = getModuleVersion([]string{"1.1.1", "2.1.1", "2.0.1"}, ">= no < version")
+	assert.EqualError(t, err, "Could not get version from string: \">=no\"")
+
+	_, err = getModuleVersion([]string{"not", "a", "version"}, ">= 2.0.0 < 2.2.0")
+	assert.EqualError(t, err, "Unable to find a valid version of this module")
+}

--- a/pkg/module_version_test.go
+++ b/pkg/module_version_test.go
@@ -6,8 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsValidVersion(t *testing.T) {
+	assert.False(t, isValidVersion("2e6b9729f3f6ea3ef5190bac0b0e1544a01fd80f"))
+	assert.False(t, isValidVersion(">= 2.0.0 < 2.2.0"))
+	assert.True(t, isValidVersion("1.1.1"))
+}
+
 func TestIsConditionalVersion(t *testing.T) {
 	assert.False(t, isConditionalVersion("2e6b9729f3f6ea3ef5190bac0b0e1544a01fd80f"))
+	assert.True(t, isConditionalVersion(">= 2.0.0 < 2.2.0"))
 	assert.True(t, isConditionalVersion("1.1.1"))
 }
 

--- a/pkg/module_version_test.go
+++ b/pkg/module_version_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsConditionalVersion(t *testing.T) {
+	assert.False(t, isConditionalVersion("2e6b9729f3f6ea3ef5190bac0b0e1544a01fd80f"))
+	assert.True(t, isConditionalVersion("1.1.1"))
+}
+
 func TestGetModuleVersion(t *testing.T) {
 	var version string
 	var err error

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -51,7 +51,7 @@ func GetRegistrySource(name string, source string, version string, services *dis
 	case isValidVersion(version):
 		_ = version
 	default:
-		modVersions = getRegistryVersions(regClient, modSrc)
+		modVersions = getRegistryModuleVersions(regClient, modSrc)
 		version, err = getModuleVersion(modVersions, version)
 		CheckIfError(name, err)
 	}
@@ -66,7 +66,7 @@ func GetRegistrySource(name string, source string, version string, services *dis
 }
 
 // Helper function to return a list of available module versions
-func getRegistryVersions(c *registry.Client, modSrc *regsrc.Module) []string {
+func getRegistryModuleVersions(c *registry.Client, modSrc *regsrc.Module) []string {
 	// Don't log from Terraform's HTTP client
 	log.SetFlags(0)
 	log.SetOutput(ioutil.Discard)

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -21,11 +21,9 @@
 package xterrafile
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 
-	"github.com/blang/semver"
 	"github.com/hashicorp/terraform/registry"
 	"github.com/hashicorp/terraform/registry/regsrc"
 	"github.com/hashicorp/terraform/svchost/disco"
@@ -42,14 +40,22 @@ func IsRegistrySourceAddr(addr string) bool {
 
 // GetRegistrySource retrieves a modules download source from a Terraform registry
 func GetRegistrySource(name string, source string, version string, services *disco.Disco) (string, string) {
+	var modVersions []string
 
 	modSrc, err := getModSrc(source)
 	CheckIfError(name, err)
 
 	regClient := registry.NewClient(services, nil)
 
-	version, err = getRegistryVersion(regClient, modSrc, version)
-	CheckIfError(name, err)
+	switch {
+	case isValidVersion(version):
+		_ = version
+	default:
+		modVersions = getRegistryVersions(regClient, modSrc)
+		version, err = getModuleVersion(modVersions, version)
+		CheckIfError(name, err)
+	}
+
 	jww.INFO.Printf("[%s] Found module version %s at %s", name, version, modSrc.Host())
 
 	regSrc, err := regClient.ModuleLocation(modSrc, version)
@@ -59,35 +65,22 @@ func GetRegistrySource(name string, source string, version string, services *dis
 	return regSrc, version
 }
 
-// Helper function to return a valid version
-func getRegistryVersion(c *registry.Client, modSrc *regsrc.Module, version string) (string, error) {
+// Helper function to return a list of available module versions
+func getRegistryVersions(c *registry.Client, modSrc *regsrc.Module) []string {
 	// Don't log from Terraform's HTTP client
 	log.SetFlags(0)
 	log.SetOutput(ioutil.Discard)
 
-	validModuleVersionRange, err := semver.ParseRange(version)
-	if err != nil {
-		return "", err
-	}
-
-	regClientResp, err := c.ModuleVersions(modSrc)
-	if err != nil {
-		return "", err
-	}
+	regClientResp, _ := c.ModuleVersions(modSrc)
 
 	regModule := regClientResp.Modules[0]
-	for _, moduleVersion := range regModule.Versions {
-		v, _ := semver.ParseTolerant(moduleVersion.Version)
+	moduleVersions := []string{}
 
-		if validModuleVersionRange(v) {
-			return v.String(), nil
-		}
+	for _, moduleVersion := range regModule.Versions {
+		moduleVersions = append(moduleVersions, moduleVersion.Version)
 	}
-	err = fmt.Errorf(
-		"Unable to find a valid version at %s newest version is %s",
-		modSrc.Host(),
-		regModule.Versions[0].Version)
-	return "", err
+
+	return moduleVersions
 }
 
 // Helper function to parse and return a module source

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -30,6 +30,14 @@ func TestGetRegistrySource(t *testing.T) {
 	assert.IsType(t, "string", module1Src, "download URL should be a string")
 	assert.IsType(t, "string", module1Version, "download version should be a string")
 
+	module1Src, module1Version = GetRegistrySource("droplet", "example.com/test-versions/name/provider", "2.1.0", test.Disco(server))
+	assert.IsType(t, "string", module1Src, "download URL should be a string")
+	assert.IsType(t, "string", module1Version, "download version should be a string")
+
+	module1Src, module1Version = GetRegistrySource("droplet", "example.com/test-versions/name/provider", "", test.Disco(server))
+	assert.IsType(t, "string", module1Src, "download URL should be a string")
+	assert.IsType(t, "string", module1Version, "download version should be a string")
+
 }
 
 func TestGetModSrc(t *testing.T) {
@@ -56,16 +64,6 @@ func TestGetRegistryVersion(t *testing.T) {
 	testClient := registry.NewClient(test.Disco(server), nil)
 
 	modSrc, _ := getModSrc("example.com/test-versions/name/provider")
-	version, _ := getRegistryVersion(testClient, modSrc, ">= 2.0.0 < 2.2.0")
-	assert.Equal(t, "2.1.1", version, "version should be >= 2.0.0 < 2.2.0")
-
-	_, err := getRegistryVersion(testClient, modSrc, ">= 3.0.0")
-	assert.Error(t, err, "should have returned an error")
-
-	_, err = getRegistryVersion(testClient, modSrc, "not.a.version")
-	assert.Error(t, err, "should return an error")
-
-	modSrc, _ = getModSrc("invalid.com/test-versions/name/provider")
-	_, err = getRegistryVersion(testClient, modSrc, ">= 3.0.0")
-	assert.Error(t, err, "should return an error")
+	versions := getRegistryVersions(testClient, modSrc)
+	assert.Equal(t, []string{"2.2.0", "2.1.1", "1.2.2", "1.2.1"}, versions)
 }

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -26,17 +26,17 @@ func TestGetRegistrySource(t *testing.T) {
 	server := test.Registry()
 	defer server.Close()
 
-	module1Src, module1Version := GetRegistrySource("droplet", "example.com/test-versions/name/provider", "2.1.x", test.Disco(server))
+	module1Src, module1Version := GetRegistrySource("droplet", "example.com/test-versions/name/provider", "1.2.x", test.Disco(server))
 	assert.IsType(t, "string", module1Src, "download URL should be a string")
-	assert.IsType(t, "string", module1Version, "download version should be a string")
+	assert.Equal(t, "1.2.2", module1Version)
 
-	module1Src, module1Version = GetRegistrySource("droplet", "example.com/test-versions/name/provider", "2.1.0", test.Disco(server))
-	assert.IsType(t, "string", module1Src, "download URL should be a string")
-	assert.IsType(t, "string", module1Version, "download version should be a string")
+	module2Src, module2Version := GetRegistrySource("droplet", "example.com/test-versions/name/provider", "2.1.0", test.Disco(server))
+	assert.IsType(t, "string", module2Src, "download URL should be a string")
+	assert.Equal(t, "2.1.0", module2Version)
 
-	module1Src, module1Version = GetRegistrySource("droplet", "example.com/test-versions/name/provider", "", test.Disco(server))
-	assert.IsType(t, "string", module1Src, "download URL should be a string")
-	assert.IsType(t, "string", module1Version, "download version should be a string")
+	module3Src, module3Version := GetRegistrySource("droplet", "example.com/test-versions/name/provider", "", test.Disco(server))
+	assert.IsType(t, "string", module3Src, "download URL should be a string")
+	assert.Equal(t, "2.2.0", module3Version)
 
 }
 

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -57,13 +57,13 @@ func TestGetModSrc(t *testing.T) {
 	assert.Panics(t, func() { module3Src.Host().Normalized() }, "accessing host should panic")
 }
 
-func TestGetRegistryVersion(t *testing.T) {
+func TestGetRegistryModuleVersions(t *testing.T) {
 	server := test.Registry()
 	defer server.Close()
 
 	testClient := registry.NewClient(test.Disco(server), nil)
 
 	modSrc, _ := getModSrc("example.com/test-versions/name/provider")
-	versions := getRegistryVersions(testClient, modSrc)
+	versions := getRegistryModuleVersions(testClient, modSrc)
 	assert.Equal(t, []string{"2.2.0", "2.1.1", "1.2.2", "1.2.1"}, versions)
 }


### PR DESCRIPTION
Closes #16 

Allows for returning a version when passed a slice of string versions and a version conditional string.

This can then be used by modules from both git and the terraform registry.