### PR TITLE
feat(versions): Add conditional versioning to Git tags

### DIFF
--- a/Terrafile.example
+++ b/Terrafile.example
@@ -7,7 +7,7 @@ terrafile-test-https:
   source: "github.com/terraform-digitalocean-modules/terraform-digitalocean-droplet.git"
 terrafile-test-tag:
   source: "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git"
-  version: "v0.1.7"
+  version: "> 0.0.2 < 0.1.1"
 terrafile-test-branch:
   source: "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git?ref=branch_test"
 terrafile-test-commit:

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -81,6 +81,9 @@ func getModule(moduleName string, moduleMeta module, wg *sync.WaitGroup) {
 	case xt.IsRegistrySourceAddr(moduleSource):
 		source, version := xt.GetRegistrySource(moduleName, moduleSource, moduleVersion, nil)
 		xt.GetWithGoGetter(moduleName, source, version, directory)
+	case xt.IsGitSourceAddr(moduleSource):
+		source, version := xt.GetGitSource(moduleName, moduleSource, moduleVersion)
+		xt.GetWithGoGetter(moduleName, source, version, directory)
 	default:
 		xt.GetWithGoGetter(moduleName, moduleSource, moduleVersion, directory)
 	}

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -1,0 +1,83 @@
+// Copyright © 2019 Tim Birkett <tim.birkett@devopsmakers.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xterrafile
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	jww "github.com/spf13/jwalterweatherman"
+)
+
+var gitSourcePrefixes = []string{
+	"git::",
+	"git@",
+}
+
+// IsGitSourceAddr returns true if the address is a git source
+func IsGitSourceAddr(addr string) bool {
+	jww.DEBUG.Printf("Testing if %s is a local source", addr)
+	for _, prefix := range gitSourcePrefixes {
+		if strings.HasPrefix(addr, prefix) || strings.HasSuffix(addr, ".git") {
+			return true
+		}
+	}
+	return false
+}
+
+// GetGitSource returns the source uri and version of a module from git
+func GetGitSource(name string, source string, version string) (string, string) {
+	var gitVersion string
+
+	switch {
+	case isConditionalVersion(version):
+		var err error
+		tagVersions := getGitTags(name, source)
+		gitVersion, err = getModuleVersion(tagVersions, version)
+		CheckIfError(name, err)
+	default:
+		gitVersion = version
+	}
+	return source, gitVersion
+}
+
+func getGitTags(name string, source string) []string {
+	var stdoutbuf bytes.Buffer
+	cmd := exec.Command("git", "ls-remote", "--tags", source)
+	cmd.Stdout = &stdoutbuf
+	err := cmd.Run()
+	CheckIfError(name, err)
+
+	var tagRegexp = regexp.MustCompile(`refs/tags/(.*)`)
+	tags := []string{}
+
+	tagScanner := bufio.NewScanner(&stdoutbuf)
+	for tagScanner.Scan() {
+		tag := tagRegexp.FindStringSubmatch(tagScanner.Text())
+		if tag != nil {
+			tags = append(tags, tag[1])
+		}
+	}
+	return tags
+}

--- a/pkg/git_test.go
+++ b/pkg/git_test.go
@@ -1,0 +1,30 @@
+package xterrafile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGitSourceAddr(t *testing.T) {
+	assert.True(t, IsGitSourceAddr("git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git"))
+	assert.True(t, IsGitSourceAddr("git::https://github.com/terraform-digitalocean-modules/terraform-digitalocean-droplet.git"))
+	assert.True(t, IsGitSourceAddr("https://github.com/terraform-digitalocean-modules/terraform-digitalocean-droplet.git"))
+	assert.False(t, IsGitSourceAddr("/some/absolute/path"), "absolute path should be false")
+	assert.False(t, IsGitSourceAddr("https://something"), "http source should be false")
+}
+
+func TestGetGitTags(t *testing.T) {
+	assert.Contains(t, getGitTags("droplet", "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git"), "v0.1.7")
+	assert.Contains(t, getGitTags("droplet", "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git"), "v0.0.2")
+}
+
+func TestGetGitSource(t *testing.T) {
+	module1Src, module1Version := GetGitSource("droplet", "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git", "> 0.1.2 <= 0.1.7")
+	assert.Equal(t, "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git", module1Src)
+	assert.Equal(t, "v0.1.7", module1Version)
+
+	module2Src, module2Version := GetGitSource("droplet", "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git", "39bda6c7aabac9226ec6628339463aa1708bef85")
+	assert.Equal(t, "git@github.com:terraform-digitalocean-modules/terraform-digitalocean-droplet.git", module2Src)
+	assert.Equal(t, "39bda6c7aabac9226ec6628339463aa1708bef85", module2Version)
+}


### PR DESCRIPTION
I added the ability to use conditional versions for Terraform
registry models in v2.0.0 of xterrafile. I wanted to see if the
same functionality would be possible for git tags. As long as
they follow a semver (examples: 1.0.0 or v1.2.0) pattern this
is now possible.

It's functional and performant but... I'm not 100% happy with
some of the code and will come back to improve on it as my
experiences and understandings grow.

Closes: #19 